### PR TITLE
Pass index trough .each()

### DIFF
--- a/src/modules/Each.js
+++ b/src/modules/Each.js
@@ -1,8 +1,8 @@
 	$.fn.each = function(callback) {
 		let set = this.set;
 		set = Array.prototype.slice.call(set);
-		set.forEach(item => {
-			callback.call(item);
+		set.forEach(function (item, index) {
+			callback.call(item, index);
 		});
 		return this;
 	};


### PR DESCRIPTION
Useful in many scenarios to have access to the index of the item currently iterated over, was that omitted on purpose?